### PR TITLE
Switch download url from bintray to binaries.sonarsource.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This LWRP manages SonarQube plugins.
 
 The `:install` action installs a SonarQube plugin to an existing SonarQube Server instance.
 Plugins are retrieved from
-[SonarSource's distribution mirror](https://sonarsource.bintray.com/Distribution/).
+[SonarSource's distribution mirror](https://binaries.sonarsource.com/Distribution/).
 The plugin version __must__ be specifed.
 
 ```ruby

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default['sonarqube']['mirror'] = 'https://sonarsource.bintray.com/Distribution/sonarqube/'
+default['sonarqube']['mirror'] = 'https://binaries.sonarsource.com/Distribution/sonarqube/'
 default['sonarqube']['version'] = '5.1.2'
 default['sonarqube']['checksum'] = 'a8d63d837242d0d07c0b3f65cfa9c84d5ae82ee51c6cbb52248bcf0d1bc58491'
 default['sonarqube']['os_kernel'] = 'linux-x86-64'

--- a/attributes/plugin.rb
+++ b/attributes/plugin.rb
@@ -1,3 +1,3 @@
-default['sonarqube']['plugin']['mirror'] = 'https://sonarsource.bintray.com/Distribution'
+default['sonarqube']['plugin']['mirror'] = 'https://binaries.sonarsource.com/Distribution'
 
 default['sonarqube']['plugin']['dir'] = "/opt/sonarqube-#{node['sonarqube']['version']}/extensions/plugins"

--- a/attributes/scanner.rb
+++ b/attributes/scanner.rb
@@ -1,4 +1,4 @@
-default['sonarqube']['scanner']['mirror'] = 'https://sonarsource.bintray.com/Distribution/sonar-scanner-cli'
+default['sonarqube']['scanner']['mirror'] = 'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli'
 default['sonarqube']['scanner']['version'] = '2.5'
 default['sonarqube']['scanner']['checksum'] = 'e2ec5f4b73aa7911f10518e304db3af0146a4347b8d06fc1d4a36b8baec0d8cc'
 


### PR DESCRIPTION
As you can see on https://www.sonarqube.org/downloads/, we (I'm working at SonarSource, the company behind SonarQube) decided to switch from bintray to our own download site.